### PR TITLE
build: allow urllib3 2.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ snakemake-interface-common = "^1.14.0"
 snakemake-interface-storage-plugins = {git="https://github.com/snakemake/snakemake-interface-storage-plugins.git", branch="dbg/test-storage"}
 boto3 = "^1.33"
 botocore = "^1.33"
-urllib3 = ">=2.0,!=2.2.0"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
+urllib3 = "!=2.2.0"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ snakemake-interface-common = "^1.14.0"
 snakemake-interface-storage-plugins = "^3.0.0"
 boto3 = "^1.33"
 botocore = "^1.33"
-urllib3 = ">=2.0,<2.2"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
+urllib3 = ">=2.0,!=2.2.0"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
https://github.com/boto/botocore/issues/3111#issuecomment-1953560852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the dependency specification for `urllib3` to exclude version 2.2.0, enhancing stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->