### PR TITLE
fix: fix retrieval of nested directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
       
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -23,7 +23,7 @@ jobs:
       - name: Determine dependencies
         run: poetry lock
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: poetry
@@ -40,7 +40,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -50,7 +50,7 @@ jobs:
       - name: Determine dependencies
         run: poetry lock
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: poetry
@@ -64,9 +64,9 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -76,7 +76,7 @@ jobs:
       - name: Determine dependencies
         run: poetry lock
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: poetry

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -34,7 +34,7 @@ jobs:
       - name: Determine dependencies
         run: poetry lock
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["snakemake", "plugin", "storage", "s3"]
 [tool.poetry.dependencies]
 python = "^3.11"
 snakemake-interface-common = "^1.14.0"
-snakemake-interface-storage-plugins = "^3.2.2"
+snakemake-interface-storage-plugins = "^3.2.4"
 boto3 = "^1.33"
 botocore = "^1.33"
 urllib3 = ">=2.0,<2.2"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
@@ -24,7 +24,7 @@ black = "^23.9.1"
 flake8 = "^6.1.0"
 coverage = "^7.3.1"
 pytest = "^7.4.2"
-snakemake = {git="https://github.com/snakemake/snakemake.git"}
+snakemake = "^8.18.0"
 setuptools = "*"
 
 [build-system]

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -295,8 +295,9 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # Ensure that the object is accessible locally under self.local_path()
         if self.is_dir():
             self.local_path().mkdir(parents=True, exist_ok=True)
-            for item in self.get_subkeys():
-                subkey = item.key.split("/", 1)[1]
+            for item in self.get_subkeys():        
+                prefix_length = len(self.s3obj().key) + 1 # + 1 for trailing slash
+                subkey = item.key[prefix_length:]
                 localpath = self.local_path() / subkey
                 localpath.parent.mkdir(parents=True, exist_ok=True)
                 item.Object().download_file(localpath)

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -295,8 +295,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         # Ensure that the object is accessible locally under self.local_path()
         if self.is_dir():
             self.local_path().mkdir(parents=True, exist_ok=True)
-            for item in self.get_subkeys():        
-                prefix_length = len(self.s3obj().key) + 1 # + 1 for trailing slash
+            for item in self.get_subkeys():
+                prefix_length = len(self.s3obj().key) + 1  # +1 for trailing slash
                 subkey = item.key[prefix_length:]
                 localpath = self.local_path() / subkey
                 localpath.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,7 +17,7 @@ class TestStorageNoSettings(TestStorageBase):
     files_only = False
 
     def get_query(self, tmp_path) -> str:
-        return "s3://snakemake-test-bucket/test-file.txt"
+        return "s3://snakemake-test-bucket/testdir1/testdir2/test-file.txt"
 
     def get_query_not_existing(self, tmp_path) -> str:
         bucket = uuid.uuid4().hex


### PR DESCRIPTION
when retrieving directories from an s3 bucket, snakemake creates a nested directory structure in the temporary `.snakemake/storage/s3` folder and cannot find the files in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependencies to the latest versions for improved stability and performance.
	- Enhanced logic for retrieving S3 objects, improving directory handling.

- **Bug Fixes**
	- Improved test cases for better accuracy in testing S3 object retrieval paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->