### PR TITLE
test: Fix tests for snakemake.settings reorganization

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,7 @@ from snakemake_interface_executor_plugins.registry import ExecutorPluginRegistry
 from snakemake.executors import local as local_executor
 from snakemake_storage_plugin_s3 import StorageProvider, StorageProviderSettings
 import snakemake.common.tests
-import snakemake.settings
+import snakemake.settings.types
 
 
 class TestStorageNoSettings(TestStorageBase):
@@ -58,5 +58,5 @@ class TestWorkflows(snakemake.common.tests.TestWorkflowsMinioPlayStorageBase):
 
     def get_remote_execution_settings(
         self,
-    ) -> snakemake.settings.RemoteExecutionSettings:
-        return snakemake.settings.RemoteExecutionSettings()
+    ) -> snakemake.settings.types.RemoteExecutionSettings:
+        return snakemake.settings.types.RemoteExecutionSettings()


### PR DESCRIPTION
In https://github.com/snakemake/snakemake/commit/ab8d2ddc38b610b0bf5b2e5368cfaf349921470a, `snakemake.settings.RemoteExecutionSettings` was moved into a new `snakemake.settings.types` module. That broke the tests:

```
$ gh repo clone snakemake/snakemake-storage-plugin-s3
$ cd snakemake-storage-plugin-s3
$ python3.12 -m venv _e
$ . _e/bin/activate
(_e) $ pip install -e .
(_e) $ pip install pytest snakemake setuptools
(_e) $ python -m pytest tests/tests.py
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/ben/src/forks/snakemake-storage-plugin-s3   
configfile: pyproject.toml
collected 0 items / 1 error                                                                                                                                                                                    

==================================================================================================== ERRORS ====================================================================================================
_______________________________________________________________________________________ ERROR collecting tests/tests.py ________________________________________________________________________________________
tests/tests.py:47: in <module>
    class TestWorkflows(snakemake.common.tests.TestWorkflowsMinioPlayStorageBase):
tests/tests.py:61: in TestWorkflows
    ) -> snakemake.settings.RemoteExecutionSettings:
E   AttributeError: module 'snakemake.settings' has no attribute 'RemoteExecutionSettings'
=========================================================================================== short test summary info ============================================================================================
ERROR tests/tests.py - AttributeError: module 'snakemake.settings' has no attribute 'RemoteExecutionSettings'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=============================================================================================== 1 error in 0.18s ===============================================================================================
```

This PR fixes the import path for `RemoteExecutionSettings` in `tests/tests.py`.