### PR TITLE
feat: Add the possibility to not forward credentials

### DIFF
--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -62,7 +62,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "S3 access key (if omitted, credentials are taken from "
             ".aws/credentials as e.g. created by aws configure)",
             "env_var": True,
-            "required": True,
+            "required": False,
         },
     )
     secret_key: Optional[str] = field(
@@ -71,7 +71,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "S3 secret key (if omitted, credentials are taken from "
             ".aws/credentials as e.g. created by aws configure)",
             "env_var": True,
-            "required": True,
+            "required": False,
         },
     )
     token: Optional[str] = field(
@@ -99,12 +99,22 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "type": int,
         },
     )
+    forward_credentials_to_remote: int = field(
+        default=1,
+        metadata={
+            "help": "When using a remote executor, forward the credentials "
+            "when spawning the job. The default is yes but it can expose credentials "
+            "which can be a security issue",
+            "env_var": False,
+            "required": False
+        }
+    )
 
     def __post_init__(self):
         session = boto3.Session()
         credentials = session.get_credentials()
 
-        if credentials:
+        if credentials and self.forward_credentials_to_remote:
             if self.access_key is None:
                 self.access_key = credentials.access_key
             if self.secret_key is None:


### PR DESCRIPTION
When using a remote executor, AWS credentials are serialized as environment variables & added as prefixes of the executed command (at least this is the case with the AWS Batch executor plugin).

This has two impacts:
 - if the executed command is logged, the credentials are logged too which can be a security issue
 - if the credentials are short lived (default is 1h on AWS), the forwarded credentials can expire before task complete. In that case, it can be better to leverage runtime credentials associated with the execution backend (job roles in AWS Batch).