### PR TITLE
build: Require boto3/botocore 1.34.63; stop pinning urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ keywords = ["snakemake", "plugin", "storage", "s3"]
 python = "^3.11"
 snakemake-interface-common = "^1.14.0"
 snakemake-interface-storage-plugins = "^3.2.2"
-boto3 = "^1.33"
-botocore = "^1.33"
-urllib3 = ">=2.0,<2.2"  # https://github.com/boto/botocore/issues/3111#issuecomment-1944524714
+# https://github.com/boto/botocore/commit/f9470df1af9f2a59d3c30f691e593d0e4abbe9e2
+boto3 = "^1.34.63"
+botocore = "^1.34.63"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Since https://github.com/boto/botocore/commit/f9470df1af9f2a59d3c30f691e593d0e4abbe9e2, botocore supports all `urllib3` versions except 2.2.0 on Python 3.10 and later. It should be safe to stop pinning `urllib3` separately here.