### PR TITLE
fix: allow boto3 to automatically refresh credentials

### DIFF
--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -100,9 +100,6 @@ class StorageProviderSettings(StorageProviderSettingsBase):
         },
     )
 
-    def __post_init__(self):
-        pass
-
 
 # Required:
 # Implementation of your storage provider

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -62,7 +62,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "S3 access key (if omitted, credentials are taken from "
             ".aws/credentials as e.g. created by aws configure)",
             "env_var": True,
-            "required": True,
+            "required": False,
         },
     )
     secret_key: Optional[str] = field(
@@ -71,7 +71,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "S3 secret key (if omitted, credentials are taken from "
             ".aws/credentials as e.g. created by aws configure)",
             "env_var": True,
-            "required": True,
+            "required": False,
         },
     )
     token: Optional[str] = field(
@@ -101,16 +101,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
     )
 
     def __post_init__(self):
-        session = boto3.Session()
-        credentials = session.get_credentials()
-
-        if credentials:
-            if self.access_key is None:
-                self.access_key = credentials.access_key
-            if self.secret_key is None:
-                self.secret_key = credentials.secret_key
-            if self.token is None:
-                self.token = credentials.token
+        pass
 
 
 # Required:


### PR DESCRIPTION
This PR makes access_key, secret_key, and token fields optional in StorageProviderSettings. This change prevents fixed credentials from overriding auto-refreshing AWS credentials, thus supporting longer operation times beyond the typical one-hour limit.

**Changes**:

Set required to False for access_key, secret_key, and token.
Removed manual override of the access_key, secret_key, and token.

**Benefits**:

Allows the application to utilize environment variables or AWS IAM roles for credentials which makes it support operations exceeding one hour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in AWS S3 credential management; `access_key` and `secret_key` are now optional in the configuration.
  
- **Bug Fixes**
	- Simplified the initialization process for AWS credentials, reducing complexity and potential errors related to credential retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->