### PR TITLE
fix: norm the path part of a given query to not contain '..' (which is invalid for S3)

### DIFF
--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 import boto3
 import botocore.exceptions
 import os
+import sys
 import posixpath
 
 from snakemake_interface_common.exceptions import WorkflowError
@@ -303,7 +304,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def mtime(self) -> float:
         # return the modification time
-        import sys; print(self.query, self.bucket, self.key, file=sys.stderr)
+        print(self.query, self.bucket, self.key, file=sys.stderr)
         if self.is_dir():
             return max(item.last_modified.timestamp() for item in self.get_subkeys())
         else:
@@ -336,7 +337,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def get_subkeys(self):
         prefix = self.s3obj().key + "/"
-        import sys; print(prefix, file=sys.stderr)
+        print(prefix, file=sys.stderr)
         return (
             item
             for item in self.s3bucket().objects.filter(Prefix=prefix)

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 import boto3
 import botocore.exceptions
 import os
-import sys
 import posixpath
 
 from snakemake_interface_common.exceptions import WorkflowError

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -225,8 +225,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             self.bucket = parsed.netloc
             # norm the path to avoid problems with double slashes and resolve ".."
             # (which is invalid for S3 keys).
-            #self.key = posixpath.normpath(parsed.path)
-            self.key = parsed.path.lstrip("/")
+            self.key = posixpath.normpath(parsed.path)
+            print(parsed.path.lstrip("/"), self.key, file=sys.stderr)
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -225,8 +225,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             self.bucket = parsed.netloc
             # norm the path to avoid problems with double slashes and resolve ".."
             # (which is invalid for S3 keys).
-            self.key = posixpath.normpath(parsed.path)
-            print("norm", parsed.path.lstrip("/"), self.key, file=sys.stderr)
+            self.key = posixpath.normpath(parsed.path.lstrip("/"))
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 
@@ -281,9 +280,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     # Here we simply rely on botos retry logic.
     def exists(self) -> bool:
         # return True if the object exists
-        # import traceback
-        # traceback.print_stack()
-        # print("exists", self.query)
         try:
             self.s3obj().load()
         except botocore.exceptions.ClientError as e:
@@ -305,7 +301,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def mtime(self) -> float:
         # return the modification time
-        print(self.query, self.bucket, self.key, file=sys.stderr)
         if self.is_dir():
             return max(item.last_modified.timestamp() for item in self.get_subkeys())
         else:
@@ -338,7 +333,6 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def get_subkeys(self):
         prefix = self.s3obj().key + "/"
-        print(prefix, file=sys.stderr)
         return (
             item
             for item in self.s3bucket().objects.filter(Prefix=prefix)

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 import boto3
 import botocore.exceptions
 import os
+import os.path
 
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase
@@ -221,7 +222,9 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         if self.is_valid_query():
             parsed = urlparse(self.query)
             self.bucket = parsed.netloc
-            self.key = parsed.path.lstrip("/")
+            # norm the path to avoid problems with double slashes and resolve ".."
+            # (which is invalid for S3 keys).
+            self.key = os.path.normpath(parsed.path)
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 
@@ -282,7 +285,15 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
         try:
             self.s3obj().load()
         except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
+            err_code = e.response["Error"]["Code"]
+            if err_code == "400":
+                raise WorkflowError(
+                    f"Bad request for S3 object {self.query}. This can happen if "
+                    "the query contains unsupported characters (e.g. '..'), "
+                    "if your credentials are invalid, or if your permissions are "
+                    "insufficient."
+                )
+            elif err_code == "404":
                 if self.bucket_exists() and self.is_dir():
                     return True
                 return False

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -224,7 +224,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             self.bucket = parsed.netloc
             # norm the path to avoid problems with double slashes and resolve ".."
             # (which is invalid for S3 keys).
-            self.key = os.path.normpath(parsed.path)
+            self.key = posixpath.normpath(parsed.path)
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 import boto3
 import botocore.exceptions
 import os
-import os.path
+import posixpath
 
 from snakemake_interface_common.exceptions import WorkflowError
 from snakemake_interface_storage_plugins.settings import StorageProviderSettingsBase

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -225,7 +225,8 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             self.bucket = parsed.netloc
             # norm the path to avoid problems with double slashes and resolve ".."
             # (which is invalid for S3 keys).
-            self.key = posixpath.normpath(parsed.path)
+            #self.key = posixpath.normpath(parsed.path)
+            self.key = parsed.path.lstrip("/")
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -303,7 +303,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def mtime(self) -> float:
         # return the modification time
-        print(self.query, self.bucket, self.key)
+        import sys; print(self.query, self.bucket, self.key, file=sys.stderr)
         if self.is_dir():
             return max(item.last_modified.timestamp() for item in self.get_subkeys())
         else:
@@ -336,7 +336,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def get_subkeys(self):
         prefix = self.s3obj().key + "/"
-        print(prefix)
+        import sys; print(prefix, file=sys.stderr)
         return (
             item
             for item in self.s3bucket().objects.filter(Prefix=prefix)

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -292,7 +292,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
                     "the query contains unsupported characters (e.g. '..'), "
                     "if your credentials are invalid, or if your permissions are "
                     "insufficient."
-                )
+                ) from e
             elif err_code == "404":
                 if self.bucket_exists() and self.is_dir():
                     return True
@@ -303,6 +303,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def mtime(self) -> float:
         # return the modification time
+        print(self.query, self.bucket, self.key)
         if self.is_dir():
             return max(item.last_modified.timestamp() for item in self.get_subkeys())
         else:
@@ -335,6 +336,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
 
     def get_subkeys(self):
         prefix = self.s3obj().key + "/"
+        print(prefix)
         return (
             item
             for item in self.s3bucket().objects.filter(Prefix=prefix)

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -226,7 +226,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             # norm the path to avoid problems with double slashes and resolve ".."
             # (which is invalid for S3 keys).
             self.key = posixpath.normpath(parsed.path)
-            print(parsed.path.lstrip("/"), self.key, file=sys.stderr)
+            print("norm", parsed.path.lstrip("/"), self.key, file=sys.stderr)
             self._local_suffix = self._local_suffix_from_key(self.key)
         self._is_dir = None
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Preserve existing behavior for missing S3 objects (404); treat other S3 errors appropriately and surface meaningful failures for bad requests (400).

- Improvements
  - Normalize S3 object keys to avoid issues with duplicate slashes and relative segments.
  - Provide clearer error messaging for malformed or unauthorized S3 requests (e.g., unsupported path segments).

- Chores
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->