### PR TITLE
fix: properly calculate dir size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = ["snakemake", "plugin", "storage", "s3"]
 [tool.poetry.dependencies]
 python = "^3.11"
 snakemake-interface-common = "^1.14.0"
-snakemake-interface-storage-plugins = "^4.1.0"
+snakemake-interface-storage-plugins = "^4.2.3"
 # https://github.com/boto/botocore/commit/f9470df1af9f2a59d3c30f691e593d0e4abbe9e2
 boto3 = "^1.34.63"
 botocore = "^1.34.63"

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -308,7 +308,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     def size(self) -> int:
         # return the size in bytes
         if self.is_dir():
-            return 0
+            return sum(item.content_length for item in self.get_subkeys())
         else:
             return self.s3obj().content_length
 

--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -308,7 +308,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
     def size(self) -> int:
         # return the size in bytes
         if self.is_dir():
-            return sum(item.content_length for item in self.get_subkeys())
+            return sum(item.size for item in self.get_subkeys())
         else:
             return self.s3obj().content_length
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Directory sizes for S3-backed storage now report the total bytes of contained objects instead of zero.

- Bug Fixes
  - More accurate directory size reporting improves disk-usage summaries, progress indicators, quota checks, and any workflows relying on directory size estimates or validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->