### PR TITLE
fix: Fix spurious missing output error when using AWS Batch executor

### DIFF
--- a/snakemake_storage_plugin_s3/__init__.py
+++ b/snakemake_storage_plugin_s3/__init__.py
@@ -326,7 +326,7 @@ class StorageObject(StorageObjectRead, StorageObjectWrite, StorageObjectGlob):
             self.s3obj().download_file(self.local_path())
 
     def is_dir(self):
-        if self._is_dir is None:
+        if not self._is_dir:
             self._is_dir = any(self.get_subkeys())
         return self._is_dir
 


### PR DESCRIPTION
When using this plugin in conjunction with the [snakemake-executor-plugin-aws-batch](https://github.com/snakemake/snakemake-executor-plugin-aws-batch), and a `directory` output from a job executed on AWS Batch, I receive the following error:
```
OSError: Missing files after 5 seconds. This might be due to filesystem latency. If that is the case, consider to increase the wait time with --latency-wait:
s3://bucket/default/storage/prefix/directory_batch (missing in storage)
```
However, the expected output objects within this prefix are created as expected from the job executed on batch. Increasing the `--latency-wait` parameter does not change the behavior.

I'm uncertain if this is really the "source" of the error, since it does not happen when running locally(still using the s3 storage plugin), but this change to recompute `_is_dir` of the `StorageObject` when it is Falsy instead of just `None` seems to resolve the issue. Someone more familiar with the internals of [snakemake-interface-storage-plugins](https://github.com/snakemake/snakemake-interface-storage-plugins)/[snakemake-interface-executor-plugins](https://github.com/snakemake/snakemake-interface-executor-plugins)/[snakemake](https://github.com/snakemake/snakemake) may be able to point to a more appropriate place to address this issue. Querying s3 more than necessary is obviously not the most elegant solution.

I'm including a Snakefile that recreates the issue, a working AWS Batch queue/compute environment and usage of a default s3 storage prefix is required to recreate the issue. I am using the latest(as of 14Oct2025) versions of `snakemake` and mentioned plugins, Python3.13, on a Ubuntu 24.04 based docker image.
```python
rule all:
    input:
        "directory_batch",
        "directory_local",

# Works fine when running locally, produces error after job completion on AWS Batch
rule directory_output_batch:
    output:
        directory_batch = directory("directory_batch"),
    shell:
        """
        mkdir -p {output.directory_batch}
        touch {output.directory_batch}/output_file
        """

# Produces no error when running fully locally or on AWS Batch
rule directory_output_local:
    localrule: True
    output:
        directory_local = directory("directory_local"),
    shell:
        """
        mkdir -p {output.directory_local}
        touch {output.directory_local}/output_file
        """
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory detection in the S3 storage plugin to ensure consistent boolean results from directory checks, preventing unexpected None values that could disrupt control flow.
  * Enhances reliability of operations that depend on directory status, such as listing contents, conditional processing, and workflow decisions in S3-backed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->